### PR TITLE
Add State Transition Data

### DIFF
--- a/src/application/ApplicationContext.cpp
+++ b/src/application/ApplicationContext.cpp
@@ -9,16 +9,16 @@ void ApplicationContext::begin() {
     mutex_init(&_stateTransitionMutex);
     _factory.setContext(this);
 
-    _currentState.state = APPLICATION_INITIAL_STATE;
-    _currentState.config[CONFIG_ID_MENU_HEADER] = String(APPLICATION_INITIAL_HEADER);
-    _currentState.inFocus = 0;
-    _controller = _factory.create(_currentState);
+    _currentStateInfo.state = APPLICATION_INITIAL_STATE;
+    _currentStateInfo.config[CONFIG_ID_MENU_HEADER] = String(APPLICATION_INITIAL_HEADER);
+    _currentStateInfo.inFocus = 0;
+    _controller = _factory.create(_currentStateInfo);
 }
 
 uint t = 0;
 
 void ApplicationContext::handle() {
-    if (_nextState.state != NullState) {
+    if (_nextStateInfo.state != NullState) {
         bool changeNow = false;
         if (_stateTransitionFlag) {
             mutex_enter_blocking(&_stateTransitionMutex);
@@ -26,33 +26,32 @@ void ApplicationContext::handle() {
             mutex_exit(&_stateTransitionMutex);
 
             DEBUG_STATE_TRANSITION_LN("_stateTransitionFlag is true -- calling _changeStateInternal");
-            _changeStateInternal(_nextState);
-            _nextState.reset();
+            _changeStateInternal(_nextStateInfo);
+            _nextStateInfo.reset();
         }
     }
 
-    if (millis() >= t + 500) {
-        Serial.println(_controller.use_count());
+    if (millis() >= t + 1000) {
+        Serial.println("Current controller ref count: " + String(_controller.use_count()));
         t = millis();
     }
 }
 
-void ApplicationContext::setNextState(StateData& state) {
+void ApplicationContext::setNextState(StateInfo& info) {
     // push current state to _previousStates
-    if (_nextState.state != NullState) {
+    if (_nextStateInfo.state != NullState) {
         DEBUG_STATE_TRANSITION_LN("Already in state transition -- Aborting");
         return;
     }
 
-    _currentState.inFocus = _controller->getInFocus();
-    _previousStates.push(_currentState);
-    
-    // transition to new state
-    _nextState = state;
+    _nextStateInfo = info;
+
+    _currentStateInfo.inFocus = _controller->getInFocus();
+    _previousStates.push(_currentStateInfo);
 }
 
 bool ApplicationContext::tryRevertState() {
-    if (_nextState.state != NullState) {
+    if (_nextStateInfo.state != NullState) {
         DEBUG_STATE_TRANSITION_LN("Already in state transition -- Aborting");
         return false;
     } else if (_previousStates.empty()) {
@@ -60,7 +59,7 @@ bool ApplicationContext::tryRevertState() {
         return false;
     }
 
-    _nextState = _previousStates.top();
+    _nextStateInfo = _previousStates.top();
     _previousStates.pop();
     return true;
 }
@@ -76,12 +75,12 @@ void ApplicationContext::setStateTransitionFlag() {
     mutex_exit(&_stateTransitionMutex);
 }
 
-void ApplicationContext::_changeStateInternal(StateData& data) {
-    _currentState = data;
+void ApplicationContext::_changeStateInternal(StateInfo& info) {
+    _currentStateInfo = info;
     
-    DEBUG_STATE_TRANSITION_LN("Changing state to: " + app_util::stateToString(data.state));
-    DEBUG_STATE_TRANSITION_LN("\t- with menu item in focus: " + String(data.inFocus));
+    DEBUG_STATE_TRANSITION_LN("Changing state to: " + app_util::stateToString(info.state));
+    DEBUG_STATE_TRANSITION_LN("\t- with menu item in focus: " + String(info.inFocus));
     DEBUG_STATE_TRANSITION_LN("_controller.use_count() = " + String(_controller.use_count()));
 
-    _controller = _factory.create(data);
+    _controller = _factory.create(info);
 }

--- a/src/application/ApplicationContext.h
+++ b/src/application/ApplicationContext.h
@@ -41,10 +41,10 @@ class ApplicationContext : public Handleable {
         void handle() override;
 
         /**
-         * @brief set next state which this context will transition to
-         * @note current state (before transition) will be added to previous states stack
+         * @brief set info for next state which this context will transition to
+         * @note current state info (before transition) will be added to previous states stack
         */
-        void setNextState(StateData& state);
+        void setNextState(StateInfo& state);
 
         /**
          * @brief trigger state change to previous state (from previous states stack)
@@ -66,16 +66,16 @@ class ApplicationContext : public Handleable {
         Adafruit_GFX& _display;
         ControllerFactory& _factory;
         std::shared_ptr<ControllerBase> _controller = nullptr;
-        StateData _currentState;
-        StateData _nextState = StateData { .state = NullState, .inFocus = 0 };
-        std::stack<StateData> _previousStates;
+        StateInfo _currentStateInfo;
+        StateInfo _nextStateInfo = StateInfo { .state = NullState, .inFocus = 0 };
+        std::stack<StateInfo> _previousStates;
         mutex_t _stateTransitionMutex;
         bool _stateTransitionFlag = false;
 
         /**
          * @brief changes state to state represented by state param
         */
-        void _changeStateInternal(StateData& state);
+        void _changeStateInternal(StateInfo& state);
 };
 
 #endif

--- a/src/application/ApplicationContext.h
+++ b/src/application/ApplicationContext.h
@@ -19,7 +19,8 @@ class ControllerFactory;
 using namespace application;
 
 // application always starts from main menu
-#define APPLICATION_INITIAL_STATE MainMenu
+#define APPLICATION_INITIAL_STATE       MainMenu
+#define APPLICATION_INITIAL_HEADER      "main menu"
 
 /**
  * @brief maintains state and state transitions of application
@@ -43,7 +44,7 @@ class ApplicationContext : public Handleable {
          * @brief set next state which this context will transition to
          * @note current state (before transition) will be added to previous states stack
         */
-        void setNextState(ApplicationState state);
+        void setNextState(StateData& state);
 
         /**
          * @brief trigger state change to previous state (from previous states stack)
@@ -65,7 +66,7 @@ class ApplicationContext : public Handleable {
         Adafruit_GFX& _display;
         ControllerFactory& _factory;
         std::shared_ptr<ControllerBase> _controller = nullptr;
-        ApplicationState _currentState = APPLICATION_INITIAL_STATE;
+        StateData _currentState;
         StateData _nextState = StateData { .state = NullState, .inFocus = 0 };
         std::stack<StateData> _previousStates;
         mutex_t _stateTransitionMutex;
@@ -74,7 +75,7 @@ class ApplicationContext : public Handleable {
         /**
          * @brief changes state to state represented by state param
         */
-        void _changeStateInternal(StateData state);
+        void _changeStateInternal(StateData& state);
 };
 
 #endif

--- a/src/application/ControllerBase.cpp
+++ b/src/application/ControllerBase.cpp
@@ -1,7 +1,7 @@
 #include "ControllerBase.h"
 
-ControllerBase::ControllerBase(ApplicationContext& context, Adafruit_GFX& display, uint8_t inFocus) :
-    _context(context), _display(display), _inFocus(inFocus) { }
+ControllerBase::ControllerBase(ApplicationContext& context, Adafruit_GFX& display) :
+    _context(context), _display(display) { }
 
 ControllerBase::~ControllerBase() {
     DEBUG_STATE_TRANSITION_LN("~ControllerBase");

--- a/src/application/ControllerBase.h
+++ b/src/application/ControllerBase.h
@@ -24,7 +24,7 @@ using namespace application;
 */
 class ControllerBase : public std::enable_shared_from_this<ControllerBase> {
     public:
-        ControllerBase(ApplicationContext& context, Adafruit_GFX& display, uint8_t inFocus = 0);
+        ControllerBase(ApplicationContext& context, Adafruit_GFX& display);
         virtual ~ControllerBase();
 
         /**

--- a/src/application/ControllerBase.h
+++ b/src/application/ControllerBase.h
@@ -41,6 +41,7 @@ class ControllerBase : public std::enable_shared_from_this<ControllerBase> {
     protected:
         ApplicationContext& _context;
         Adafruit_GFX& _display;
+        StateInfo _info;
         uint8_t _inFocus = 0;
 
         /* hardware input handlers (assigned as InputCallback in init) */

--- a/src/application/ControllerFactory.cpp
+++ b/src/application/ControllerFactory.cpp
@@ -4,21 +4,21 @@
 #include "ControllerMenu.h"
 
 
-const std::vector<ControllerMenu::MenuButtonData> mainMenuConfig = {
-    { ControllerMenu::MenuButtonData { .state = CalibrationMenu, .text = "Run Calibration" } },
-    { ControllerMenu::MenuButtonData { .state = ManualControlMenu, .text = "Manual Control" } },
-    { ControllerMenu::MenuButtonData { .state = TextDialog, .text = "Text Dialog" } }
+const std::vector<ControllerMenu::MenuButtonInfo> mainMenuConfig = {
+    { ControllerMenu::MenuButtonInfo { .state = CalibrationMenu, .text = "Run Calibration" } },
+    { ControllerMenu::MenuButtonInfo { .state = ManualControlMenu, .text = "Manual Control" } },
+    { ControllerMenu::MenuButtonInfo { .state = TextDialog, .text = "Text Dialog" } }
 };
 
-const std::vector<ControllerMenu::MenuButtonData> calibrationMenuConfig = {
-    { ControllerMenu::MenuButtonData { .state = CalibrationMode, .text = "Begin Calibration" } },
-    { ControllerMenu::MenuButtonData { .state = CalibrationSettings, .text = "Calibration Settings" } }
+const std::vector<ControllerMenu::MenuButtonInfo> calibrationMenuConfig = {
+    { ControllerMenu::MenuButtonInfo { .state = CalibrationMode, .text = "Begin Calibration" } },
+    { ControllerMenu::MenuButtonInfo { .state = CalibrationSettings, .text = "Calibration Settings" } }
 };
 
 ControllerFactory::ControllerFactory(Adafruit_GFX& display, InputManager& manager) :
     _display(display), _inputManager(manager) { }
 
-std::shared_ptr<ControllerBase> ControllerFactory::create(StateData& data) {
+std::shared_ptr<ControllerBase> ControllerFactory::create(StateInfo& data) {
     return _createInternal(data);
 }
 
@@ -26,7 +26,7 @@ void ControllerFactory::setContext(ApplicationContext* context) {
     _context = context;
 }
 
-std::shared_ptr<ControllerBase> ControllerFactory::_createInternal(StateData& data) {
+std::shared_ptr<ControllerBase> ControllerFactory::_createInternal(StateInfo& data) {
     std::shared_ptr<ControllerBase> ret = nullptr;
     switch (data.state) {
         case MainMenu:

--- a/src/application/ControllerFactory.cpp
+++ b/src/application/ControllerFactory.cpp
@@ -3,10 +3,11 @@
 #include "ControllerFactory.h"
 #include "ControllerMenu.h"
 
+
 const std::vector<ControllerMenu::MenuButtonData> mainMenuConfig = {
     { ControllerMenu::MenuButtonData { .state = CalibrationMenu, .text = "Run Calibration" } },
     { ControllerMenu::MenuButtonData { .state = ManualControlMenu, .text = "Manual Control" } },
-    { ControllerMenu::MenuButtonData { .state = SettingsMenu, .text = "Settings" } }
+    { ControllerMenu::MenuButtonData { .state = TextDialog, .text = "Text Dialog" } }
 };
 
 const std::vector<ControllerMenu::MenuButtonData> calibrationMenuConfig = {
@@ -17,12 +18,7 @@ const std::vector<ControllerMenu::MenuButtonData> calibrationMenuConfig = {
 ControllerFactory::ControllerFactory(Adafruit_GFX& display, InputManager& manager) :
     _display(display), _inputManager(manager) { }
 
-std::shared_ptr<ControllerBase> ControllerFactory::create(ApplicationState state) {
-    StateData data { .state = state, .inFocus = 0 };
-    return _createInternal(data);
-}
-
-std::shared_ptr<ControllerBase> ControllerFactory::create(StateData data) {
+std::shared_ptr<ControllerBase> ControllerFactory::create(StateData& data) {
     return _createInternal(data);
 }
 
@@ -30,21 +26,19 @@ void ControllerFactory::setContext(ApplicationContext* context) {
     _context = context;
 }
 
-std::shared_ptr<ControllerBase> ControllerFactory::_createInternal(StateData data) {
+std::shared_ptr<ControllerBase> ControllerFactory::_createInternal(StateData& data) {
     std::shared_ptr<ControllerBase> ret = nullptr;
     switch (data.state) {
         case MainMenu:
-            ret = std::make_shared<ControllerMenu>(*_context, _display, data.inFocus);
-            static_cast<ControllerMenu*>(ret.get())->getView().setHeader("main menu");
-            static_cast<ControllerMenu*>(ret.get())->init(_inputManager, mainMenuConfig);
+            ret = std::make_shared<ControllerMenu>(*_context, _display);
+            static_cast<ControllerMenu*>(ret.get())->init(_inputManager, data, mainMenuConfig);
             break;
         case ManualControlMenu:
             // TODO: add ManualControlMenu implementation
             break;
         case CalibrationMenu:
-            ret = std::make_shared<ControllerMenu>(*_context, _display, data.inFocus);
-            static_cast<ControllerMenu*>(ret.get())->getView().setHeader("calibration setup");
-            static_cast<ControllerMenu*>(ret.get())->init(_inputManager, calibrationMenuConfig);
+            ret = std::make_shared<ControllerMenu>(*_context, _display);
+            static_cast<ControllerMenu*>(ret.get())->init(_inputManager, data, calibrationMenuConfig);
             break;
         case SettingsMenu:
             // TODO: add SettingsMenu implementation

--- a/src/application/ControllerFactory.h
+++ b/src/application/ControllerFactory.h
@@ -23,18 +23,11 @@ class ControllerFactory {
         ControllerFactory(Adafruit_GFX& display, InputManager& manager);
 
         /**
-         * @brief create new controller base class for state
-         * @return pointer to new ControllerBase
-         * @note delete must be called on returned object when it is disposed of
-        */
-        std::shared_ptr<ControllerBase> create(ApplicationState state);
-
-        /**
          * @brief create new controller base class for state data
          * @return pointer to new ControllerBase
          * @note delete must be called on returned object when it is disposed of
         */
-        std::shared_ptr<ControllerBase> create(StateData state);
+        std::shared_ptr<ControllerBase> create(StateData& state);
         void setContext(ApplicationContext* context);
 
     private:
@@ -47,7 +40,7 @@ class ControllerFactory {
          * @return pointer to new ControllerBase
          * @note delete must be called on returned object when it is disposed of
         */
-        std::shared_ptr<ControllerBase> _createInternal(StateData data);
+        std::shared_ptr<ControllerBase> _createInternal(StateData& data);
 };
 
 #endif

--- a/src/application/ControllerFactory.h
+++ b/src/application/ControllerFactory.h
@@ -23,11 +23,11 @@ class ControllerFactory {
         ControllerFactory(Adafruit_GFX& display, InputManager& manager);
 
         /**
-         * @brief create new controller base class for state data
+         * @brief create new controller base class for state info
          * @return pointer to new ControllerBase
          * @note delete must be called on returned object when it is disposed of
         */
-        std::shared_ptr<ControllerBase> create(StateData& state);
+        std::shared_ptr<ControllerBase> create(StateInfo& state);
         void setContext(ApplicationContext* context);
 
     private:
@@ -36,11 +36,11 @@ class ControllerFactory {
         ApplicationContext* _context;
 
         /**
-         * @brief constructs new controller class for state data
+         * @brief constructs new controller class for state info
          * @return pointer to new ControllerBase
          * @note delete must be called on returned object when it is disposed of
         */
-        std::shared_ptr<ControllerBase> _createInternal(StateData& data);
+        std::shared_ptr<ControllerBase> _createInternal(StateInfo& data);
 };
 
 #endif

--- a/src/application/ControllerMenu.cpp
+++ b/src/application/ControllerMenu.cpp
@@ -11,17 +11,18 @@ ControllerMenu::~ControllerMenu() {
     DEBUG_STATE_TRANSITION_LN("~ControllerMenu");
 }
 
-void ControllerMenu::init(InputManager& manager, StateData& state, const std::vector<MenuButtonData>& buttonConfigs) {
+void ControllerMenu::init(InputManager& manager, StateData& data, const std::vector<MenuButtonData>& buttonConfigs) {
     // register all input callbacks with input manager
     ControllerBase::init(manager);
 
     DEBUG_STATE_TRANSITION_LN("Initializing new ControllerMenu");
     DEBUG_STATE_TRANSITION_LN("buttonConfigs.size() = " + String(buttonConfigs.size()));
 
-    if (state.config.find(CONFIG_ID_MENU_HEADER) == state.config.end()) {
-        _menu->setHeader(state.config[CONFIG_ID_MENU_HEADER]);
+    if (data.config.find(CONFIG_ID_MENU_HEADER) != data.config.end()) {
+        DEBUG_STATE_TRANSITION_LN("Setting header to: " + data.config[CONFIG_ID_MENU_HEADER]);
+        _menu->setHeader(data.config[CONFIG_ID_MENU_HEADER]);
     }
-    _inFocus = state.inFocus;
+    _inFocus = data.inFocus;
 
     for (uint8_t i = 0; i < buttonConfigs.size(); i++) {
         const MenuButtonData& buttonConfig = buttonConfigs[i];
@@ -30,13 +31,14 @@ void ControllerMenu::init(InputManager& manager, StateData& state, const std::ve
         DEBUG_STATE_TRANSITION_LN("state: " + app_util::stateToString(buttonConfig.state) + " -- text: " + buttonConfig.text);
 
         // copy state data and create transition state data for button
-        StateData data = state;
-        data.config[CONFIG_ID_MENU_HEADER] = buttonConfig.text;
+        StateData buttonData = data;
+        buttonData.state = buttonConfig.state;
+        buttonData.config[CONFIG_ID_MENU_HEADER] = buttonConfig.text;
 
         // create menu button with associated capture lambda
         std::shared_ptr<UIButton> button = std::make_shared<UIButton>(_display);
         _menu->addMenuButton(button, buttonConfig.text);
-        _buttonStatePairs.push_back(std::make_pair(button, data));
+        _buttonStatePairs.push_back(std::make_pair(button, buttonData));
     }
 
     auto self = shared_from_this();

--- a/src/application/ControllerMenu.h
+++ b/src/application/ControllerMenu.h
@@ -23,7 +23,7 @@ class ControllerMenu : public ControllerBase {
         /**
          * @brief menu button configuration data with display text and state which button transitions to
         */
-        struct MenuButtonData {
+        struct MenuButtonInfo {
             application::ApplicationState state;
             const String text;
         };
@@ -36,7 +36,7 @@ class ControllerMenu : public ControllerBase {
          * @param manager input manager which will be set to update this controller with UI events
          * @param buttonConfigs ui button data to configure the interactive buttons of this menu
         */
-        void init(InputManager& manager, StateData& state, const std::vector<MenuButtonData>& buttonConfigs);
+        void init(InputManager& manager, StateInfo& state, const std::vector<MenuButtonInfo>& buttonConfigs);
 
         /**
          * @brief returns view associated with this controller
@@ -45,7 +45,7 @@ class ControllerMenu : public ControllerBase {
 
     private:
         std::shared_ptr<MenuView> _menu;
-        std::vector<std::pair<std::shared_ptr<UIButton>, StateData>> _buttonStatePairs;
+        std::vector<std::pair<std::shared_ptr<UIButton>, MenuButtonInfo>> _buttonInfoPairs;
         bool _buttonHeld = false;
 
         // ControllerBase already provides default input handler implementations, so you only

--- a/src/application/ControllerMenu.h
+++ b/src/application/ControllerMenu.h
@@ -2,6 +2,7 @@
 #define _CONTROLLER_MENU_H_
 
 #include <vector>
+#include <utility>
 #include <memory>
 
 #include "settings.h"
@@ -27,7 +28,7 @@ class ControllerMenu : public ControllerBase {
             const String text;
         };
 
-        ControllerMenu(ApplicationContext& context, Adafruit_GFX& display, uint8_t inFocus = 0);
+        ControllerMenu(ApplicationContext& context, Adafruit_GFX& display);
         ~ControllerMenu();
 
         /**
@@ -35,7 +36,7 @@ class ControllerMenu : public ControllerBase {
          * @param manager input manager which will be set to update this controller with UI events
          * @param buttonConfigs ui button data to configure the interactive buttons of this menu
         */
-        void init(InputManager& manager, const std::vector<MenuButtonData>& buttonConfigs);
+        void init(InputManager& manager, StateData& state, const std::vector<MenuButtonData>& buttonConfigs);
 
         /**
          * @brief returns view associated with this controller
@@ -44,7 +45,7 @@ class ControllerMenu : public ControllerBase {
 
     private:
         std::shared_ptr<MenuView> _menu;
-        std::map<uint8_t, std::pair<std::shared_ptr<UIElement>, std::function<void()>>> _buttonCallbackMap;
+        std::vector<std::pair<std::shared_ptr<UIButton>, StateData>> _buttonStatePairs;
         bool _buttonHeld = false;
 
         // ControllerBase already provides default input handler implementations, so you only

--- a/src/application/application.h
+++ b/src/application/application.h
@@ -1,6 +1,8 @@
 #ifndef _APPLICATION_H_
 #define _APPLICATION_H_
 
+#include <unordered_map>
+
 namespace application {
     /**
      * @brief ApplicationState is enum representing all application states
@@ -13,14 +15,18 @@ namespace application {
         CalibrationMenu = 2,
         SettingsMenu = 3,
         CalibrationMode = 4,
-        CalibrationSettings = 5
+        CalibrationSettings = 5,
+        TextDialog = 6
     };
 
     /**
      * @brief represents state information which can be used for transitions and navigation
+     * @note you can think of this data structure as a json settings object, as the config map is a
+     * dictionary which can be used to store arbitrary state information
     */
     struct StateData {
         ApplicationState state;
+        std::unordered_map<uint8_t, String> config;
         uint8_t inFocus;
 
         /**
@@ -29,8 +35,12 @@ namespace application {
         void reset() {
             state = NullState;
             inFocus = 0;
+            config.clear();
         }
     };
+
+    /* config ids */
+    #define CONFIG_ID_MENU_HEADER       0
 }
 
 #endif

--- a/src/application/application.h
+++ b/src/application/application.h
@@ -24,7 +24,7 @@ namespace application {
      * @note you can think of this data structure as a json settings object, as the config map is a
      * dictionary which can be used to store arbitrary state information
     */
-    struct StateData {
+    struct StateInfo {
         ApplicationState state;
         std::unordered_map<uint8_t, String> config;
         uint8_t inFocus;


### PR DESCRIPTION
## Notes
This was a necessary design step that I skipped earlier because I first wanted to build out a class which requires passing data between states.  The PR for that isn't up yet, as its implementation also depends on this code.  This PR renames a bunch of the 'data' structs 'info' structs, as that's what they really were in the first place.

The most important addition is the _config_ field in the StateInfo (formerly StateData) struct.  This field is a map (or dictionary if you'd like) which takes a property id in the form of a uint8 and returns info associated with that key, if it exists.  This allows Controller classes to check for data they might want or need when setting up their UI elements or displaying data.

## Changes

#### Application Context
- rename __currentState_ and __nextState_ to __currentStateInfo_, __nextStateInfo_
- _begin_: adds text header field to StateInfo::config before passing the state info object to the controller factory for construction
- _setNextState_: changes param from _ApplicationState_ to _StateInfo_, so Controller can pass config info to next controller which will be instantiated

#### ControllerBase
- constructor no longer takes inFocus param, as that information is now passed into derived classes' init methods with StateInfo object

#### ControllerFactory
- _create_ now only takes StateInfo object

#### ControllerMenu
- strips down unordered_map _buttonToCallback to a vector of pairs--the unordered map was using sequential indices from 0 as keys, so it was basically a vector anyways
- replaces callback functions with MenuButtonInfo objects--all callbacks were calling ApplicationContext::setNextState anyways so there was no need for that flexibility

closes #52