### PR TITLE
Replace Local Stack-based Configs with Global Settings Object

### DIFF
--- a/src/application/ApplicationContext.h
+++ b/src/application/ApplicationContext.h
@@ -19,7 +19,8 @@ class ControllerFactory;
 using namespace application;
 
 // application always starts from main menu
-#define APPLICATION_INITIAL_STATE MainMenu
+#define APPLICATION_INITIAL_STATE       MainMenu
+#define APPLICATION_INITIAL_HEADER      "main menu"
 
 /**
  * @brief maintains state and state transitions of application
@@ -40,10 +41,18 @@ class ApplicationContext : public Handleable {
         void handle() override;
 
         /**
-         * @brief set next state which this context will transition to
-         * @note current state (before transition) will be added to previous states stack
+         * @brief try to set info for next state which this context will transition to
+         * @returns bool indicating whether or not state transition has been triggered
+         * @note current state info (before transition) will be added to previous states stack
         */
-        void setNextState(ApplicationState state);
+        bool trySetNextState(StateInfo& state);
+
+        /**
+         * @brief try updating and transitioning to previous state with current info (eg. return from config menu)
+         * @returns bool indicating whether or not state transition has been triggered
+         * @note current state info (before transition) will be added to previous states stack
+        */
+        bool tryUpdateAndReturn(StateInfo& state);
 
         /**
          * @brief trigger state change to previous state (from previous states stack)
@@ -65,16 +74,16 @@ class ApplicationContext : public Handleable {
         Adafruit_GFX& _display;
         ControllerFactory& _factory;
         std::shared_ptr<ControllerBase> _controller = nullptr;
-        ApplicationState _currentState = APPLICATION_INITIAL_STATE;
-        StateData _nextState = StateData { .state = NullState, .inFocus = 0 };
-        std::stack<StateData> _previousStates;
+        StateInfo _currentStateInfo;
+        StateInfo _nextStateInfo = StateInfo { .state = NullState, .inFocus = 0 };
+        std::stack<StateInfo> _previousStates;
         mutex_t _stateTransitionMutex;
         bool _stateTransitionFlag = false;
 
         /**
          * @brief changes state to state represented by state param
         */
-        void _changeStateInternal(StateData state);
+        void _changeStateInternal(StateInfo& state);
 };
 
 #endif

--- a/src/application/ControllerBase.cpp
+++ b/src/application/ControllerBase.cpp
@@ -1,10 +1,10 @@
 #include "ControllerBase.h"
 
-ControllerBase::ControllerBase(ApplicationContext& context, Adafruit_GFX& display, uint8_t inFocus) :
-    _context(context), _display(display), _inFocus(inFocus) { }
+ControllerBase::ControllerBase(ApplicationContext& context, Adafruit_GFX& display) :
+    _context(context), _display(display) { }
 
 ControllerBase::~ControllerBase() {
-    DEBUG_STATE_TRANSITION_LN("~ControllerBase");
+    DEBUG_SERIAL_LN("~ControllerBase");
 }
 
 void ControllerBase::init(InputManager& manager) {
@@ -19,6 +19,10 @@ void ControllerBase::init(InputManager& manager) {
 
 uint8_t ControllerBase::getInFocus() {
     return _inFocus;
+}
+
+StateInfo ControllerBase::getStateInfo() {
+    return _info;
 }
 
 /* Input handlers (assigned as InputCallback in init) */

--- a/src/application/ControllerBase.h
+++ b/src/application/ControllerBase.h
@@ -24,7 +24,7 @@ using namespace application;
 */
 class ControllerBase : public std::enable_shared_from_this<ControllerBase> {
     public:
-        ControllerBase(ApplicationContext& context, Adafruit_GFX& display, uint8_t inFocus = 0);
+        ControllerBase(ApplicationContext& context, Adafruit_GFX& display);
         virtual ~ControllerBase();
 
         /**
@@ -38,9 +38,15 @@ class ControllerBase : public std::enable_shared_from_this<ControllerBase> {
         */
 		uint8_t getInFocus();
 
+        /**
+         * @brief returns current state info object
+        */
+       StateInfo getStateInfo();
+
     protected:
         ApplicationContext& _context;
         Adafruit_GFX& _display;
+        StateInfo _info;
         uint8_t _inFocus = 0;
 
         /* hardware input handlers (assigned as InputCallback in init) */

--- a/src/application/ControllerFactory.cpp
+++ b/src/application/ControllerFactory.cpp
@@ -3,48 +3,48 @@
 #include "ControllerFactory.h"
 #include "ControllerMenu.h"
 
-const std::vector<ControllerMenu::MenuButtonData> mainMenuConfig = {
-    { ControllerMenu::MenuButtonData { .state = CalibrationMenu, .text = "Run Calibration" } },
-    { ControllerMenu::MenuButtonData { .state = ManualControlMenu, .text = "Manual Control" } },
-    { ControllerMenu::MenuButtonData { .state = SettingsMenu, .text = "Settings" } }
+const std::vector<ControllerMenu::MenuButtonInfo> mainMenuConfig = {
+    { ControllerMenu::MenuButtonInfo {
+        .text = "Run Calibration",
+        .info = { .state = CalibrationMenu } } },
+    { ControllerMenu::MenuButtonInfo {
+        .text = "Manual Control",
+        .info = { .state = ManualControlMenu } } },
+    { ControllerMenu::MenuButtonInfo {
+            .text = "Text Dialog",
+            .info = { .state = TextDialog, .config = {
+                { CONFIG_ID_EDIT_STRING_ID, String(CONFIG_ID_DEFAULT_OUTPUT_FILENAME) }, } } } }
 };
 
-const std::vector<ControllerMenu::MenuButtonData> calibrationMenuConfig = {
-    { ControllerMenu::MenuButtonData { .state = CalibrationMode, .text = "Begin Calibration" } },
-    { ControllerMenu::MenuButtonData { .state = CalibrationSettings, .text = "Calibration Settings" } }
+const std::vector<ControllerMenu::MenuButtonInfo> calibrationMenuConfig = {
+    { ControllerMenu::MenuButtonInfo { .text = "Begin Calibration", .info { .state = CalibrationMode } } },
+    { ControllerMenu::MenuButtonInfo { .text = "Calibration Settings", .info { .state = CalibrationSettings } } },
 };
 
 ControllerFactory::ControllerFactory(Adafruit_GFX& display, InputManager& manager) :
     _display(display), _inputManager(manager) { }
 
-std::shared_ptr<ControllerBase> ControllerFactory::create(ApplicationState state) {
-    StateData data { .state = state, .inFocus = 0 };
-    return _createInternal(data);
-}
-
-std::shared_ptr<ControllerBase> ControllerFactory::create(StateData data) {
-    return _createInternal(data);
+std::shared_ptr<ControllerBase> ControllerFactory::create(StateInfo& info) {
+    return _createInternal(info);
 }
 
 void ControllerFactory::setContext(ApplicationContext* context) {
     _context = context;
 }
 
-std::shared_ptr<ControllerBase> ControllerFactory::_createInternal(StateData data) {
+std::shared_ptr<ControllerBase> ControllerFactory::_createInternal(StateInfo& info) {
     std::shared_ptr<ControllerBase> ret = nullptr;
-    switch (data.state) {
+    switch (info.state) {
         case MainMenu:
-            ret = std::make_shared<ControllerMenu>(*_context, _display, data.inFocus);
-            static_cast<ControllerMenu*>(ret.get())->getView().setHeader("main menu");
-            static_cast<ControllerMenu*>(ret.get())->init(_inputManager, mainMenuConfig);
+            ret = std::make_shared<ControllerMenu>(*_context, _display);
+            static_cast<ControllerMenu*>(ret.get())->init(_inputManager, info, mainMenuConfig);
             break;
         case ManualControlMenu:
             // TODO: add ManualControlMenu implementation
             break;
         case CalibrationMenu:
-            ret = std::make_shared<ControllerMenu>(*_context, _display, data.inFocus);
-            static_cast<ControllerMenu*>(ret.get())->getView().setHeader("calibration setup");
-            static_cast<ControllerMenu*>(ret.get())->init(_inputManager, calibrationMenuConfig);
+            ret = std::make_shared<ControllerMenu>(*_context, _display);
+            static_cast<ControllerMenu*>(ret.get())->init(_inputManager, info, calibrationMenuConfig);
             break;
         case SettingsMenu:
             // TODO: add SettingsMenu implementation

--- a/src/application/ControllerFactory.h
+++ b/src/application/ControllerFactory.h
@@ -23,18 +23,11 @@ class ControllerFactory {
         ControllerFactory(Adafruit_GFX& display, InputManager& manager);
 
         /**
-         * @brief create new controller base class for state
+         * @brief create new controller base class for state info
          * @return pointer to new ControllerBase
          * @note delete must be called on returned object when it is disposed of
         */
-        std::shared_ptr<ControllerBase> create(ApplicationState state);
-
-        /**
-         * @brief create new controller base class for state data
-         * @return pointer to new ControllerBase
-         * @note delete must be called on returned object when it is disposed of
-        */
-        std::shared_ptr<ControllerBase> create(StateData state);
+        std::shared_ptr<ControllerBase> create(StateInfo& state);
         void setContext(ApplicationContext* context);
 
     private:
@@ -43,11 +36,11 @@ class ControllerFactory {
         ApplicationContext* _context;
 
         /**
-         * @brief constructs new controller class for state data
+         * @brief constructs new controller class for state info
          * @return pointer to new ControllerBase
          * @note delete must be called on returned object when it is disposed of
         */
-        std::shared_ptr<ControllerBase> _createInternal(StateData data);
+        std::shared_ptr<ControllerBase> _createInternal(StateInfo& data);
 };
 
 #endif

--- a/src/application/ControllerMenu.cpp
+++ b/src/application/ControllerMenu.cpp
@@ -2,35 +2,44 @@
 
 using namespace application;
 
-ControllerMenu::ControllerMenu(ApplicationContext& context, Adafruit_GFX& display, uint8_t inFocus) :
-    ControllerBase(context, display, inFocus) {
+ControllerMenu::ControllerMenu(ApplicationContext& context, Adafruit_GFX& display) :
+    ControllerBase(context, display) {
         _menu = std::make_shared<MenuView>(display);
 }
 
 ControllerMenu::~ControllerMenu() {
-    DEBUG_STATE_TRANSITION_LN("~ControllerMenu");
+    DEBUG_SERIAL_LN("~ControllerMenu");
 }
 
-void ControllerMenu::init(InputManager& manager, const std::vector<MenuButtonData>& buttonConfigs) {
+void ControllerMenu::init(InputManager& manager, StateInfo& info, const std::vector<MenuButtonInfo>& buttonConfigs) {
     // register all input callbacks with input manager
     ControllerBase::init(manager);
 
-    DEBUG_STATE_TRANSITION_LN("Initializing new ControllerMenu");
-    DEBUG_STATE_TRANSITION_LN("buttonConfigs.size() = " + String(buttonConfigs.size()));
-    for (uint8_t i = 0; i < buttonConfigs.size(); i++) {
-        const MenuButtonData& data = buttonConfigs[i];
+    DEBUG_SERIAL_LN("Initializing new ControllerMenu");
+    DEBUG_SERIAL_LN("buttonConfigs.size() = " + String(buttonConfigs.size()));
 
-        DEBUG_STATE_TRANSITION_LN("ButtonData:");
-        DEBUG_STATE_TRANSITION_LN("state: " + app_util::stateToString(data.state) + " -- text: " + data.text);
-        std::shared_ptr<UIButton> cur = std::make_shared<UIButton>(_display);
-        _menu->addMenuButton(cur, data.text);
-        _buttonCallbackMap[i] = std::make_pair(cur, [this, data]() { _context.setNextState(data.state); });
+    _menu->setHeader(info.header);
+    _info = info; // cache state info (we need to pass config to next state)
+    _inFocus = info.inFocus;
+
+    for (uint8_t i = 0; i < buttonConfigs.size(); i++) {
+        const MenuButtonInfo& buttonInfo = buttonConfigs[i];
+
+        DEBUG_SERIAL_LN("ButtonData:");
+        DEBUG_SERIAL_LN("state: " + app_util::stateToString(buttonInfo.info.state) + " -- text: " + buttonInfo.text);
+
+        // create menu button with associated capture lambda
+        std::shared_ptr<UIButton> button = std::make_shared<UIButton>(_display);
+        _menu->addMenuButton(button, buttonInfo.text);
+        _buttonInfoPairs.push_back(std::make_pair(button, buttonInfo));
     }
 
     auto self = shared_from_this();
-    auto cur = _buttonCallbackMap[_inFocus].first;
-    UIEventHandler::instance().addEvent( [this, self]() { _menu->init(); } );
-    UIEventHandler::instance().addEvent( [cur]() { cur->focus(); } );
+    auto cur = _buttonInfoPairs[_inFocus].first;
+    UIEventHandler::instance().addEvent( [this, self, cur]() {
+            _menu->init();
+            cur->focus();
+        });
 }
 
 MenuView& ControllerMenu::getView() {
@@ -80,7 +89,7 @@ void ControllerMenu::_handleInputEncoderSelect(input_data_t d) {
 
 void ControllerMenu::_handleInputBack(input_data_t d) {
     // if (d) {
-    //     UIElement* cur = _buttonCallbackMap[_inFocus].first;
+    //     UIElement* cur = _buttonInfoPairs[_inFocus].first;
     //     UIEventHandler::instance().addEvent([this,cur]() { cur->focus(); _menu->back(); });
     // } else {
     //     _navigateBack();
@@ -110,22 +119,21 @@ void ControllerMenu::_navigateBack() {
 
 void ControllerMenu::_shiftFocus(int32_t offset) {
     DEBUG_SERIAL_LN("Shift Focus");
-    auto cur = _buttonCallbackMap[_inFocus].first;
-    UIEventHandler::instance().addEvent( [cur]() { cur->revert(); } );
+    auto cur = _buttonInfoPairs[_inFocus].first;
+    auto self = shared_from_this();
+    UIEventHandler::instance().addEvent( [cur, self]() { cur->revert(); } );
 
     // compute index of new focussed element
-    int32_t modVal = _buttonCallbackMap.size();
-    input_data_t val = ((_inFocus + offset) % modVal + modVal) % modVal;
-    _inFocus = static_cast<uint8_t>(val);
+    _inFocus = static_cast<uint8_t>(_computeIndexOffset(_inFocus, offset, _buttonInfoPairs.size()));
 
     // focus new element
-    cur = _buttonCallbackMap[_inFocus].first;
-    UIEventHandler::instance().addEvent([cur]() { cur->focus(); });
+    cur = _buttonInfoPairs[_inFocus].first;
+    UIEventHandler::instance().addEvent([cur, self]() { cur->focus(); });
 }
 
 void ControllerMenu::_selectCurrent() {
     DEBUG_STATE_TRANSITION_LN("Select Current");
-    auto cur = _buttonCallbackMap[_inFocus].first;
+    auto cur = _buttonInfoPairs[_inFocus].first;
     auto self = shared_from_this();
     UIEventHandler::instance().addEvent([this, cur, self]() {
             cur->select();
@@ -134,16 +142,24 @@ void ControllerMenu::_selectCurrent() {
 }
 
 void ControllerMenu::_triggerStateChange() {
+    // update _info object before call
+    MenuButtonInfo buttonInfo = _buttonInfoPairs[_inFocus].second;
+    _info.state = buttonInfo.info.state;
+    _info.inFocus = 0;
+    _info.header = buttonInfo.text;
+    _info.addToConfig(buttonInfo.info);
+
+    if (!_context.trySetNextState(_info)) {
+        return;
+    }
+
     DEBUG_STATE_TRANSITION_LN("Trigger State Changed");
-    auto cur = _buttonCallbackMap[_inFocus].first;
+    auto button = _buttonInfoPairs[_inFocus].first;
     auto self = shared_from_this();
     UIEventHandler::instance().addEvent(
-        [this, cur, self]() {
-            cur->revert();
+        [this, button, self]() {
+            button->revert();
             _menu->revert();
             _context.setStateTransitionFlag(); // set flag after render actions are complete
         });
-    (_buttonCallbackMap[_inFocus].second)();
 }
-
-

--- a/src/application/ControllerMenu.h
+++ b/src/application/ControllerMenu.h
@@ -2,6 +2,7 @@
 #define _CONTROLLER_MENU_H_
 
 #include <vector>
+#include <utility>
 #include <memory>
 
 #include "settings.h"
@@ -22,12 +23,12 @@ class ControllerMenu : public ControllerBase {
         /**
          * @brief menu button configuration data with display text and state which button transitions to
         */
-        struct MenuButtonData {
-            application::ApplicationState state;
+        struct MenuButtonInfo {
             const String text;
+            StateInfo info;
         };
 
-        ControllerMenu(ApplicationContext& context, Adafruit_GFX& display, uint8_t inFocus = 0);
+        ControllerMenu(ApplicationContext& context, Adafruit_GFX& display);
         ~ControllerMenu();
 
         /**
@@ -35,7 +36,7 @@ class ControllerMenu : public ControllerBase {
          * @param manager input manager which will be set to update this controller with UI events
          * @param buttonConfigs ui button data to configure the interactive buttons of this menu
         */
-        void init(InputManager& manager, const std::vector<MenuButtonData>& buttonConfigs);
+        void init(InputManager& manager, StateInfo& state, const std::vector<MenuButtonInfo>& buttonConfigs);
 
         /**
          * @brief returns view associated with this controller
@@ -44,7 +45,7 @@ class ControllerMenu : public ControllerBase {
 
     private:
         std::shared_ptr<MenuView> _menu;
-        std::map<uint8_t, std::pair<std::shared_ptr<UIElement>, std::function<void()>>> _buttonCallbackMap;
+        std::vector<std::pair<std::shared_ptr<UIButton>, MenuButtonInfo>> _buttonInfoPairs;
         bool _buttonHeld = false;
 
         // ControllerBase already provides default input handler implementations, so you only

--- a/src/application/application.cpp
+++ b/src/application/application.cpp
@@ -1,0 +1,18 @@
+#ifndef __APPLICATION_H_
+#define __APPLICATION_H_
+
+#include "application.h"
+
+using namespace application;
+
+// copy of config macros for reference
+// #define CONFIG_ID_EDIT_STRING_ID          0
+// #define CONFIG_ID_DEFAULT_CSV_FILENAME      1
+// #define CONFIG_ID_DIALOG_START_STRING       2
+
+std::unordered_map<uint8_t, String> application::GlobalSettings = {
+    { CONFIG_ID_DEFAULT_OUTPUT_FILENAME, "default-out.csv" },
+    { CONFIG_ID_DEFAULT_OUTPUT_FILENAME, "default-in.csv" },
+};
+
+#endif

--- a/src/application/application.h
+++ b/src/application/application.h
@@ -1,6 +1,10 @@
 #ifndef _APPLICATION_H_
 #define _APPLICATION_H_
 
+#include <unordered_map>
+
+#include "settings.h"
+
 namespace application {
     /**
      * @brief ApplicationState is enum representing all application states
@@ -13,24 +17,59 @@ namespace application {
         CalibrationMenu = 2,
         SettingsMenu = 3,
         CalibrationMode = 4,
-        CalibrationSettings = 5
+        CalibrationSettings = 5,
+        TextDialog = 6
     };
 
     /**
      * @brief represents state information which can be used for transitions and navigation
+     * @note you can think of this data structure as a json settings object, as the config map is a
+     * dictionary which can be used to store arbitrary state information
     */
-    struct StateData {
+    struct StateInfo {
         ApplicationState state;
-        uint8_t inFocus;
+        String header = "";
+        std::unordered_map<uint8_t, String> config;
+        uint8_t inFocus = 0;
 
         /**
          * @brief reset to null state
         */
         void reset() {
             state = NullState;
+            header = "";
             inFocus = 0;
+            config.clear();
+        }
+
+        /**
+         * @brief add everything in info.config to this StateInfo config
+        */
+        void addToConfig(StateInfo& info) {
+            for (auto const& pair : info.config) {
+                config[pair.first] = pair.second;
+            }
+        }
+
+        void print() {
+            DEBUG_SERIAL_LN(" -- State Info Object -- ");
+            DEBUG_SERIAL_LN("\tstate:\t" + String(state));
+            DEBUG_SERIAL_LN("\theader:\t" + header);
+            DEBUG_SERIAL_LN("\tinFocus:\t" + String((int)inFocus));
+            DEBUG_SERIAL_LN("\tconfig:");
+            for (auto const& pair : config) {
+                DEBUG_SERIAL_LN("\t\t{ " + String((int)pair.first) + ", " + pair.second + " } " );
+            }
         }
     };
+
+    extern std::unordered_map<uint8_t, String> GlobalSettings;
+
+    /* config ids */
+    #define CONFIG_ID_EDIT_STRING_ID            0
+    #define CONFIG_ID_DEFAULT_OUTPUT_FILENAME   1
+    #define CONFIG_ID_DEFAULT_INPUT_FILENAME    2
+    #define CONFIG_ID_DIALOG_START_STRING       3
 }
 
 #endif


### PR DESCRIPTION
- renames StateData struct to StateInfo, as it is really an info object
- adds header field to StateInfo struct
- adds ApplicationContext::tryUpdateAndReturn for states which update some local or global configuration before returning to previous state (settings menus)
- renames ApplicationContext::trySetNextState, which now returns bool indicating whether or not state transition has been triggered
- renames all StateData 'data' objects to 'info' objects
- adds GlobalSettings dictionary which will store settings for current user session (eventually will be populated with saved user settings from disk)
- renames MenuButtonConfig to MenuButtonInfo and adds StateInfo field, so button configurations in ControllerFactory can contain much more explicit information about what UI buttons do
- adds info object getter to ControllerBase class
- modifies and improves comments and performs some simple refactoring in ControllerMenu class