### PR TITLE
Remove usage of 64 bit variables

### DIFF
--- a/src/Sensor/SensorForce.h
+++ b/src/Sensor/SensorForce.h
@@ -36,7 +36,7 @@ class SensorForce : public Sensor {
         float _force;
         uint8_t _pinNumber;
         PinMode _pinMode;
-        uint64_t _lastReadTime = 0;
+        uint32_t _lastReadTime = 0;
 };
 
 #endif

--- a/src/Sensor/SensorOptical.cpp
+++ b/src/Sensor/SensorOptical.cpp
@@ -38,7 +38,7 @@ void SensorOptical::handle() {
         int32_t n = currentCount - _lastUpdateCount;
         uint32_t deltaT = currentTime - _lastUpdateTime;
 
-        _angularVelocity = ((double)n / NUM_APERTURES) * 2 * _PI * (MEGA / (double)deltaT);
+        _angularVelocity = ((float)n / NUM_APERTURES) * 2 * _PI * (MEGA / (float)deltaT);
         _lastUpdateCount = currentCount;
         _lastUpdateTime = currentTime;
     }
@@ -59,10 +59,10 @@ uint32_t SensorOptical::getReadInterval() {
     return _readInterval;
 }
 
-double SensorOptical::getAngularVelocity() {
+float SensorOptical::getAngularVelocity() {
     return _angularVelocity;
 }
 
-double SensorOptical::getLinearVelocity() {
+float SensorOptical::getLinearVelocity() {
     return VELOCITY_FACTOR * _angularVelocity;
 }

--- a/src/Sensor/SensorOptical.cpp
+++ b/src/Sensor/SensorOptical.cpp
@@ -4,11 +4,11 @@
 // div of 8.0 works fine, but will count 2x when pio runs any faster
 #define PIO_CLOCK_DIV 8.0f
 #define MEGA 1000000
-#define _PI 3.1415
+#define _PI 3.1415f
 
 #define NUM_APERTURES 64
-#define GEAR_RATIO 0.2 
-#define ROLLER_RADIUS 0.08276057 // metres
+#define GEAR_RATIO 0.2f
+#define ROLLER_RADIUS 0.08276057f // metres
 #define VELOCITY_FACTOR (GEAR_RATIO * ROLLER_RADIUS) // speed of vehicle [m/s] = velocity factor * angular velocity [rad/s]
 
 const uint16_t SensorOptical::NumApertures = NUM_APERTURES;

--- a/src/Sensor/SensorOptical.h
+++ b/src/Sensor/SensorOptical.h
@@ -19,8 +19,8 @@ class SensorOptical: public Sensor {
         String getHumanName() override;
         void begin() override;
         void handle() override;
-        double getAngularVelocity();
-        double getLinearVelocity();
+        float getAngularVelocity();
+        float getLinearVelocity();
         void setReadInterval(uint32_t interval);
         uint32_t getReadInterval();
 
@@ -30,7 +30,7 @@ class SensorOptical: public Sensor {
         uint32_t _lastUpdateTime = 0;
         int32_t _lastUpdateCount = 0;
         uint32_t _readInterval = 0;
-        double _angularVelocity = 0;
+        float _angularVelocity = 0;
 
         #ifdef DEBUG_OPTICAL_ENABLED
         int32_t _lastDisplayCount = 0;


### PR DESCRIPTION
This PR replaces doubles with floats in the Optical Sensor code.

There are still some longs and doubles in the `lib/` and `test/` folder that I did not touch.