### PR TITLE
Navigation menu configs

### DIFF
--- a/src/application/ControllerFactory.cpp
+++ b/src/application/ControllerFactory.cpp
@@ -82,14 +82,14 @@ std::shared_ptr<ControllerBase> ControllerFactory::_createInternal(StateInfo& in
 
 const NavMenuConfig MainMenuConfig = {
     { ButtonInfo {
-        .text = "Run Calibration",
-        .info = { .state = CalibrationMenu } } },
-    { ButtonInfo {
         .text = "Manual Control",
         .info = { .state = ManualControlMenu } } },
     { ButtonInfo {
         .text = "Automated Control",
         .info = { .state = AutoControlMenu } } },
+    { ButtonInfo {
+        .text = "Calibration",
+        .info = { .state = CalibrationMenu } } },
     { ButtonInfo {
         .text = "Settings",
         .info = { .state = GlobalSettingsMenu } } }

--- a/src/application/ControllerFactory.cpp
+++ b/src/application/ControllerFactory.cpp
@@ -97,15 +97,15 @@ const NavMenuConfig MainMenuConfig = {
 
 const NavMenuConfig CalibrationMenuConfig = {
     { ButtonInfo { .text = "Begin Calibration", .info { .state = CalibrationMode } } },
-    { ButtonInfo { .text = "Calibration Settings", .info { .state = CalibrationSettings } } }
+    { ButtonInfo { .text = "Settings", .info { .state = CalibrationSettings } } }
 };
 
 const NavMenuConfig AutoControlMenuConfig = {
     { ButtonInfo { .text = "Start Session", .info { .state = AutoControlMode } } },
-    { ButtonInfo { .text = "Automation Settings", .info { .state = AutoControlSettings } } }
+    { ButtonInfo { .text = "Settings", .info { .state = AutoControlSettings } } }
 };
 
 const NavMenuConfig ManualControlMenuConfig = {
     { ButtonInfo { .text = "Start Session", .info { .state = ManualControlMode } } },
-    { ButtonInfo { .text = "Manual Settings", .info { .state = ManualControlSettings } } }
+    { ButtonInfo { .text = "Settings", .info { .state = ManualControlSettings } } }
 };

--- a/src/application/ControllerFactory.cpp
+++ b/src/application/ControllerFactory.cpp
@@ -4,23 +4,17 @@
 #include "ControllerMenu.h"
 #include "TextDialogController.h"
 
-const std::vector<ControllerMenu::MenuButtonInfo> mainMenuConfig = {
-    { ControllerMenu::MenuButtonInfo {
-        .text = "Run Calibration",
-        .info = { .state = CalibrationMenu } } },
-    { ControllerMenu::MenuButtonInfo {
-        .text = "Manual Control",
-        .info = { .state = ManualControlMenu } } },
-    { ControllerMenu::MenuButtonInfo {
-            .text = "Text Dialog",
-            .info = { .state = TextDialog, .config = {
-                { CONFIG_ID_EDIT_STRING_ID, String(CONFIG_ID_DEFAULT_OUTPUT_FILENAME) }, } } } }
-};
+// menu configs
 
-const std::vector<ControllerMenu::MenuButtonInfo> calibrationMenuConfig = {
-    { ControllerMenu::MenuButtonInfo { .text = "Begin Calibration", .info { .state = CalibrationMode } } },
-    { ControllerMenu::MenuButtonInfo { .text = "Calibration Settings", .info { .state = CalibrationSettings } } },
-};
+typedef std::vector<ControllerMenu::MenuButtonInfo> NavMenuConfig;
+typedef ControllerMenu::MenuButtonInfo ButtonInfo;
+
+extern const NavMenuConfig MainMenuConfig;
+extern const NavMenuConfig CalibrationMenuConfig;
+extern const NavMenuConfig AutoControlMenuConfig;
+extern const NavMenuConfig ManualControlMenuConfig;
+
+// controller factory
 
 ControllerFactory::ControllerFactory(Adafruit_GFX& display, InputManager& manager) :
     _display(display), _inputManager(manager) { }
@@ -38,17 +32,40 @@ std::shared_ptr<ControllerBase> ControllerFactory::_createInternal(StateInfo& in
     switch (info.state) {
         case MainMenu:
             ret = std::make_shared<ControllerMenu>(*_context, _display);
-            static_cast<ControllerMenu*>(ret.get())->init(_inputManager, info, mainMenuConfig);
+            static_cast<ControllerMenu*>(ret.get())->init(_inputManager, info, MainMenuConfig);
             break;
-        case ManualControlMenu:
-            // TODO: add ManualControlMenu implementation
+        case GlobalSettingsMenu:
+            // TODO: add SettingsMenu implementation
             break;
         case CalibrationMenu:
             ret = std::make_shared<ControllerMenu>(*_context, _display);
-            static_cast<ControllerMenu*>(ret.get())->init(_inputManager, info, calibrationMenuConfig);
+            static_cast<ControllerMenu*>(ret.get())->init(_inputManager, info, CalibrationMenuConfig);
             break;
-        case SettingsMenu:
-            // TODO: add SettingsMenu implementation
+        case CalibrationMode:
+            // TODO: add calibration mode state
+            break;
+        case CalibrationSettings:
+            // TODO: add calibration settings state
+            break;
+        case AutoControlMenu:
+            ret = std::make_shared<ControllerMenu>(*_context, _display);
+            static_cast<ControllerMenu*>(ret.get())->init(_inputManager, info, AutoControlMenuConfig);
+            break;
+        case AutoControlMode:
+            // TODO: add auto control mode state
+            break;
+        case AutoControlSettings:
+            // TODO: add auto control settings state
+            break;
+        case ManualControlMenu:
+            ret = std::make_shared<ControllerMenu>(*_context, _display);
+            static_cast<ControllerMenu*>(ret.get())->init(_inputManager, info, ManualControlMenuConfig);
+            break;
+        case ManualControlMode:
+            // TODO: add manual control mode state
+            break;
+        case ManualControlSettings:
+            // TODO: add manual control settings state
             break;
         case TextDialog:
             ret = std::make_shared<TextDialogController>(*_context, _display);
@@ -60,3 +77,35 @@ std::shared_ptr<ControllerBase> ControllerFactory::_createInternal(StateInfo& in
     }
     return ret;
 }
+
+// menu configs
+
+const NavMenuConfig MainMenuConfig = {
+    { ButtonInfo {
+        .text = "Run Calibration",
+        .info = { .state = CalibrationMenu } } },
+    { ButtonInfo {
+        .text = "Manual Control",
+        .info = { .state = ManualControlMenu } } },
+    { ButtonInfo {
+        .text = "Automated Control",
+        .info = { .state = AutoControlMenu } } },
+    { ButtonInfo {
+        .text = "Settings",
+        .info = { .state = GlobalSettingsMenu } } }
+};
+
+const NavMenuConfig CalibrationMenuConfig = {
+    { ButtonInfo { .text = "Begin Calibration", .info { .state = CalibrationMode } } },
+    { ButtonInfo { .text = "Calibration Settings", .info { .state = CalibrationSettings } } }
+};
+
+const NavMenuConfig AutoControlMenuConfig = {
+    { ButtonInfo { .text = "Start Session", .info { .state = AutoControlMode } } },
+    { ButtonInfo { .text = "Automation Settings", .info { .state = AutoControlSettings } } }
+};
+
+const NavMenuConfig ManualControlMenuConfig = {
+    { ButtonInfo { .text = "Start Session", .info { .state = ManualControlMode } } },
+    { ButtonInfo { .text = "Manual Settings", .info { .state = ManualControlSettings } } }
+};

--- a/src/application/app_util.cpp
+++ b/src/application/app_util.cpp
@@ -87,16 +87,26 @@ const String app_util::stateToString(ApplicationState state) {
     switch (state) {
         case MainMenu:
             return "Main Menu";
-        case ManualControlMenu:
-            return "Manual Control";
+        case GlobalSettingsMenu:
+            return "Global Settings";
         case CalibrationMenu:
-            return "Calibration";
-        case SettingsMenu:
-            return "Settings";
+            return "Calibration Menu";
         case CalibrationMode:
             return "Calibration Mode";
         case CalibrationSettings:
             return "Calibration Settings";
+        case AutoControlMenu:
+            return "Manual Control Menu";
+        case AutoControlMode:
+            return "Manual Control Mode";
+        case AutoControlSettings:
+            return "Manual Control Settings";
+        case ManualControlMenu:
+            return "Manual Control Menu";
+        case ManualControlMode:
+            return "Manual Control Mode";
+        case ManualControlSettings:
+            return "Manual Control Settings";
         case TextDialog:
             return "Text Dialog";
         default:

--- a/src/application/application.h
+++ b/src/application/application.h
@@ -12,13 +12,18 @@ namespace application {
     */
     enum ApplicationState {
         NullState = -1,
-        MainMenu = 0,
-        ManualControlMenu = 1,
-        CalibrationMenu = 2,
-        SettingsMenu = 3,
-        CalibrationMode = 4,
-        CalibrationSettings = 5,
-        TextDialog = 6
+        MainMenu,
+        GlobalSettingsMenu,
+        CalibrationMenu,
+        CalibrationMode,
+        CalibrationSettings,
+        AutoControlMenu,
+        AutoControlMode,
+        AutoControlSettings,
+        ManualControlMenu,
+        ManualControlMode,
+        ManualControlSettings,
+        TextDialog,
     };
 
     /**


### PR DESCRIPTION
- adds nav menu configs for calibration, automated control and manual control menus, and enums corresponding to each
- also adds construction logic in for new nav menus in ```ControllerFactory```, and new enum cases in ```app_util::stateToString```
- threw in some TODOs for new enums in ```ControllerFactory``` as well

closes #46