### PR TITLE
Adds virtual handle method to ControllerBase

### DIFF
--- a/src/application/ApplicationContext.cpp
+++ b/src/application/ApplicationContext.cpp
@@ -31,6 +31,8 @@ void ApplicationContext::handle() {
         }
     }
 
+    _controller->handle();
+    
     if (millis() >= last_ref_count + 1000) {
         DEBUG_SERIAL_LN("Current controller ref count: " + String(_controller.use_count()));
         last_ref_count = millis();

--- a/src/application/ControllerBase.cpp
+++ b/src/application/ControllerBase.cpp
@@ -17,6 +17,10 @@ void ControllerBase::init(InputManager& manager) {
     manager.registerAction(ID_BRAKE_POT, [this](input_data_t d) { this->_handleInputBrakePot(d); });
 }
 
+void ControllerBase::handle() {
+    // default: do nothing
+}
+
 uint8_t ControllerBase::getInFocus() {
     return _inFocus;
 }

--- a/src/application/ControllerBase.h
+++ b/src/application/ControllerBase.h
@@ -34,6 +34,11 @@ class ControllerBase : public std::enable_shared_from_this<ControllerBase> {
         virtual void init(InputManager& manager);
 
         /**
+         * @brief run controller
+        */
+        virtual void handle();
+
+        /**
          * @brief returns index of current ui element in focus
         */
 		uint8_t getInFocus();


### PR DESCRIPTION
Certain ui states will need to be handled every control loop for certain behaviors (logging data, for example). Adding a handle method to the Controller class heirarchy makes this possible.

Base implementation doesn't do anything, because not all Controller classes need to update every control loop.