### PR TITLE
Creates simple type id system for ui elements

### DIFF
--- a/src/application/MenuView.cpp
+++ b/src/application/MenuView.cpp
@@ -27,10 +27,7 @@ void MenuView::init() {
     app_util::configureMenuContainer(_menuContainer.get());
     app_util::configureNavButtonContainer(_navButtonContainer.get());
     
-    // order matters for alignment: align top-level container first, then down
     _window->align();
-    _menuContainer->align();
-    _navButtonContainer->align();
 
     // call to principal container draws all elements
     DEBUG_SERIAL_LN("Drawing window");

--- a/src/application/TextDialogView.cpp
+++ b/src/application/TextDialogView.cpp
@@ -47,8 +47,6 @@ void TextDialogView::init() {
     
     // order matters for alignment: align top-level container first, then down
     _window->align();
-    _textContainer->align();
-    _navButtonContainer->align();
     
     // call to principal container draws all elements
     DEBUG_SERIAL_LN("Drawing window");

--- a/src/ui/CircularElement.cpp
+++ b/src/ui/CircularElement.cpp
@@ -1,7 +1,9 @@
 #include "CircularElement.h"
 
 CircularElement::CircularElement(TFT_eSPI& display) :
-    VisualElement(display) { }
+    VisualElement(display) {
+        _typeId |= TYPE_ID_CIRCULAR_ELEMENT;
+}
 
 CircularElement::~CircularElement() { }
 

--- a/src/ui/Container.cpp
+++ b/src/ui/Container.cpp
@@ -3,7 +3,9 @@
 #define CONTAINER_HORIZONTAL_BITMASK    0xf
 #define CONTAINER_VERTICAL_BITMASK      0xf0
 
-Container::Container(TFT_eSPI& display) : RectangularElement(display) { }
+Container::Container(TFT_eSPI& display) : RectangularElement(display) {
+    _typeId |= TYPE_ID_CONTAINER;
+}
 
 Container::~Container() { }
 
@@ -49,6 +51,11 @@ void Container::align() {
             break;
         default:
             break;
+    }
+    for (auto& pair : _children) {
+        if (pair.first->getTypeId() & TYPE_ID_CONTAINER) {
+            static_cast<Container*>(pair.first.get())->align();
+        }
     }
 }
 

--- a/src/ui/RectangularElement.cpp
+++ b/src/ui/RectangularElement.cpp
@@ -1,7 +1,9 @@
 #include "RectangularElement.h"
 
 RectangularElement::RectangularElement(TFT_eSPI& display) :
-    VisualElement(display) { }
+    VisualElement(display) {
+        _typeId |= TYPE_ID_RECTANGULAR_ELEMENT;
+}
 
 RectangularElement::~RectangularElement() { }
 

--- a/src/ui/TextElement.cpp
+++ b/src/ui/TextElement.cpp
@@ -3,6 +3,8 @@
 #include "graphics/colour.h"
 
 TextElement::TextElement(TFT_eSPI& display, bool numeric) : RectangularElement(display) {
+    _typeId |= TYPE_ID_TEXT_ELEMENT;
+
     if (numeric) {
         _textComponent = std::make_shared<ValueTextComponent>();
     } else {

--- a/src/ui/UIButton.cpp
+++ b/src/ui/UIButton.cpp
@@ -1,6 +1,7 @@
 #include "UIButton.h"
 
 UIButton::UIButton(TFT_eSPI& display) : UIElement(display) {
+    _typeId |= TYPE_ID_UI_BUTTON;
     _textComponent.setOwner(this);
 }
 

--- a/src/ui/UIElement.cpp
+++ b/src/ui/UIElement.cpp
@@ -1,6 +1,8 @@
 #include "UIElement.h"
 
-UIElement::UIElement(TFT_eSPI& display) : RectangularElement(display) { }
+UIElement::UIElement(TFT_eSPI& display) : RectangularElement(display) {
+    _typeId |= TYPE_ID_UI_ELEMENT;
+}
 
 void UIElement::focus() {
     _drawInternal(_focusColour);

--- a/src/ui/ValueElement.cpp
+++ b/src/ui/ValueElement.cpp
@@ -2,6 +2,7 @@
 
 
 ValueElement::ValueElement(TFT_eSPI& display) : Container(display) {
+    _typeId |= TYPE_ID_VALUE_ELEMENT;
     _labelElement = std::make_shared<TextElement>(_display);
     _valueElement = std::make_shared<TextElement>(_display, true);
     _unitsElement = std::make_shared<TextElement>(_display);

--- a/src/ui/VisualElement.cpp
+++ b/src/ui/VisualElement.cpp
@@ -9,6 +9,10 @@ VisualElement& VisualElement::setParent(VisualElement* parent) {
     return *this;
 }
 
+uint16_t VisualElement::getTypeId() {
+    return _typeId;
+}
+
 Point VisualElement::getPosition() {
     return _position;
 }

--- a/src/ui/VisualElement.h
+++ b/src/ui/VisualElement.h
@@ -17,6 +17,11 @@ class VisualElement {
         VisualElement& setParent(VisualElement* parent);
         
         /**
+         * @brief returns unique id for each UI type
+        */
+        uint16_t getTypeId();
+
+        /**
          * @brief get position (top left corner)
         */
         Point getPosition();
@@ -69,6 +74,7 @@ class VisualElement {
         uint16_t _backgroundColour = 0;
         uint16_t _borderColour = 0;
         int16_t _borderWidth = 0;
+        uint16_t _typeId = TYPE_ID_VISUAL_ELEMENT;
         bool _hasBorder = false;
 
         /**

--- a/src/ui/ui_util.h
+++ b/src/ui/ui_util.h
@@ -5,6 +5,15 @@
 #include <functional>
 #include "TFT_eSPI.h"
 
+#define TYPE_ID_VISUAL_ELEMENT       0x0
+#define TYPE_ID_UI_ELEMENT           0x1
+#define TYPE_ID_RECTANGULAR_ELEMENT  0x2
+#define TYPE_ID_CIRCULAR_ELEMENT     0x4
+#define TYPE_ID_CONTAINER            0x8
+#define TYPE_ID_TEXT_ELEMENT         0x10
+#define TYPE_ID_UI_BUTTON            0x20
+#define TYPE_ID_VALUE_ELEMENT        0x40
+
 namespace ui_util {
 
     /**
@@ -86,7 +95,6 @@ namespace ui_util {
                 maxHeight = cur.y;
             }
         }
-
         return Point { width, maxHeight };
     }
 }


### PR DESCRIPTION
It wasn't very elegant to have to keep track of the ui container hierarchy so they could be aligned in the right order.  This is a pretty simple fix to that problem.

- uses flags to construct id from type hierarchy
- allows for downcasting (like in the case of Container::align())

