### PR TITLE
Fix Rotary Encoder Issue #83

### DIFF
--- a/src/System/HardwareRotaryEncoder.h
+++ b/src/System/HardwareRotaryEncoder.h
@@ -25,14 +25,24 @@ class HardwareRotaryEncoder : public HardwareInput {
         void run() override {
             PinStatus valA = digitalRead(_pinA);
             
-            if (valA != _lastA) {
+            if (valA != _lastA) { //When a change in a state of input A is detected (when a rotation in either direction is detected)
                 PinStatus valB = digitalRead(_pinB);    
                 
-                if (valA && valB) {
-                    ++_counter;
-                } else if (valA && !valB) {
-                    --_counter;
+                if (valA != valB){
+                    ++_counter; //when rotating counterclockwise
                 }
+                else if (valA == valB){
+                    --_counter; //when rotating clockwise
+                }
+
+                /* Original
+                if (valA && valB) {
+                    ++_counter; /ccw
+                
+                } else if (valA && !valB) {
+                    --_counter; /cw
+                }
+                */
                 _lastA = valA;
             }
 

--- a/src/System/HardwareRotaryEncoder.h
+++ b/src/System/HardwareRotaryEncoder.h
@@ -35,14 +35,6 @@ class HardwareRotaryEncoder : public HardwareInput {
                     --_counter; //when rotating clockwise
                 }
 
-                /* Original
-                if (valA && valB) {
-                    ++_counter; /ccw
-                
-                } else if (valA && !valB) {
-                    --_counter; /cw
-                }
-                */
                 _lastA = valA;
             }
 


### PR DESCRIPTION
An error in the rotary encoder was fixed.
Here is the explanation.
If the rotary encoder follows this convention:
![image](https://github.com/supermileage/dynamometer-firmware/assets/91859687/11c0c0bb-2226-425b-8e30-4ce4200041f8)
where inputA is 90 degrees out of phase with inputB and input A goes first, then the original code:

if (valA != _lastA) {
PinStatus valB = digitalRead(_pinB);

            if (valA && valB) {
                ++_counter; /ccw
            
            } else if (valA && !valB) {
                --_counter; /cw
            }
/more code/
}

only considers situations where A is originally on a logic low (0) and goes to logic high (1).
If A is originally on a logic high (1) and goes to a logic low (0), it isn't considered.
Therefore, wiggling the rotary encoder in place such that when A oscillates between the same (1) and (0) connections, it simulates a rotation even though there isn't one.

The fix we came up with is this:

void run() override {
PinStatus valA = digitalRead(_pinA);

        if (valA != _lastA) { //When a change in a state of input A is detected (when a rotation in either direction is detected)
            PinStatus valB = digitalRead(_pinB);    
            
            if (valA != valB){
                ++_counter; //when rotating counterclockwise
            }
            else if (valA == valB){
                --_counter; //when rotating clockwise
            }

            _lastA = valA;
        }
/more code/
}