### PR TITLE
Temporary Fix to Disable Pico Crashing When Selecting an Undeveloped Menu

### DIFF
--- a/src/application/ControllerFactory.cpp
+++ b/src/application/ControllerFactory.cpp
@@ -36,6 +36,8 @@ std::shared_ptr<ControllerBase> ControllerFactory::_createInternal(StateInfo& in
             break;
         case GlobalSettingsMenu:
             // TODO: add SettingsMenu implementation
+            ret = std::make_shared<ControllerMenu>(*_context, _display);
+            static_cast<ControllerMenu*>(ret.get())->init(_inputManager, info, MainMenuConfig);
             break;
         case CalibrationMenu:
             ret = std::make_shared<ControllerMenu>(*_context, _display);
@@ -43,9 +45,13 @@ std::shared_ptr<ControllerBase> ControllerFactory::_createInternal(StateInfo& in
             break;
         case CalibrationMode:
             // TODO: add calibration mode state
+            ret = std::make_shared<ControllerMenu>(*_context, _display);
+            static_cast<ControllerMenu*>(ret.get())->init(_inputManager, info, CalibrationMenuConfig);
             break;
         case CalibrationSettings:
             // TODO: add calibration settings state
+            ret = std::make_shared<ControllerMenu>(*_context, _display);
+            static_cast<ControllerMenu*>(ret.get())->init(_inputManager, info, CalibrationMenuConfig);
             break;
         case AutoControlMenu:
             ret = std::make_shared<ControllerMenu>(*_context, _display);
@@ -53,9 +59,13 @@ std::shared_ptr<ControllerBase> ControllerFactory::_createInternal(StateInfo& in
             break;
         case AutoControlMode:
             // TODO: add auto control mode state
+            ret = std::make_shared<ControllerMenu>(*_context, _display);
+            static_cast<ControllerMenu*>(ret.get())->init(_inputManager, info, AutoControlMenuConfig);
             break;
         case AutoControlSettings:
             // TODO: add auto control settings state
+            ret = std::make_shared<ControllerMenu>(*_context, _display);
+            static_cast<ControllerMenu*>(ret.get())->init(_inputManager, info, AutoControlMenuConfig);
             break;
         case ManualControlMenu:
             ret = std::make_shared<ControllerMenu>(*_context, _display);
@@ -63,9 +73,13 @@ std::shared_ptr<ControllerBase> ControllerFactory::_createInternal(StateInfo& in
             break;
         case ManualControlMode:
             // TODO: add manual control mode state
+            ret = std::make_shared<ControllerMenu>(*_context, _display);
+            static_cast<ControllerMenu*>(ret.get())->init(_inputManager, info, ManualControlMenuConfig);
             break;
         case ManualControlSettings:
             // TODO: add manual control settings state
+            ret = std::make_shared<ControllerMenu>(*_context, _display);
+            static_cast<ControllerMenu*>(ret.get())->init(_inputManager, info, ManualControlMenuConfig);
             break;
         case TextDialog:
             ret = std::make_shared<TextDialogController>(*_context, _display);


### PR DESCRIPTION
The Pico would crash when the user selects a menu which hasnt been developed yet. This change makes it so it goes back to the previous menu if a non developed menu is selected. This will have to be changed as menus get developed, though.